### PR TITLE
fix: change company name in place of first name of contact card

### DIFF
--- a/utils/vcard.js
+++ b/utils/vcard.js
@@ -3,7 +3,7 @@ export function generateVCard(visitor) {
 BEGIN:VCARD
 VERSION:3.0
 FN:${visitor.name}
-ORG:${visitor.company || ''}
+ORG:${visitor.name || ''}
 EMAIL:${visitor.email || ''}
 TEL:${visitor.phone || ''}
 ADR:;;${visitor.address || ''}


### PR DESCRIPTION
Fixed vcard to show first name instead of company name in the contacts.