### PR TITLE
fix(kiosk): stabilize station route and assigned survey loading

### DIFF
--- a/imports/api/_roles.helpers.js
+++ b/imports/api/_roles.helpers.js
@@ -1,28 +1,31 @@
 // /imports/api/_roles.helpers.js
+import { Meteor } from 'meteor/meteor';
 import { Roles } from 'meteor/alanning:roles';
 
 export async function assertAdminAsync(userId) {
-    if (!userId) throw new Meteor.Error('not-authorized', 'Login required');
+  if (!userId) throw new Meteor.Error('not-authorized', 'Login required');
 
-    // Prefer async when available
-    if (typeof Roles.userIsInRoleAsync === 'function') {
-        const ok = await Roles.userIsInRoleAsync(userId, 'admin');
-        if (!ok) throw new Meteor.Error('not-authorized', 'Admin role required');
-        return;
-    }
+  // Prefer async when available
+  if (typeof Roles.userIsInRoleAsync === 'function') {
+    const ok = await Roles.userIsInRoleAsync(userId, 'admin');
+    if (!ok) throw new Meteor.Error('not-authorized', 'Admin role required');
+    return;
+  }
 
-    // Fallback to sync read
-    if (typeof Roles.userIsInRole === 'function') {
-        if (!Roles.userIsInRole(userId, 'admin')) {
-            throw new Meteor.Error('not-authorized', 'Admin role required');
-        }
-        return;
+  // Fallback to sync read
+  if (typeof Roles.userIsInRole === 'function') {
+    if (!Roles.userIsInRole(userId, 'admin')) {
+      throw new Meteor.Error('not-authorized', 'Admin role required');
     }
+    return;
+  }
 
-    // Last resort
-    const roles = (typeof Roles.getRolesForUser === 'function')
-        ? Roles.getRolesForUser(userId) : [];
-    if (!Array.isArray(roles) || !roles.includes('admin')) {
-        throw new Meteor.Error('not-authorized', 'Admin role required');
-    }
+  // Last resort
+  const roles =
+    typeof Roles.getRolesForUser === 'function'
+      ? Roles.getRolesForUser(userId)
+      : [];
+  if (!Array.isArray(roles) || !roles.includes('admin')) {
+    throw new Meteor.Error('not-authorized', 'Admin role required');
+  }
 }

--- a/imports/api/methods.js
+++ b/imports/api/methods.js
@@ -75,8 +75,10 @@ Meteor.methods({
       address: Match.Optional(String),
       purpose: Match.Optional(String),
       dob: Match.Optional(String),
-      host: Match.Optional(String), // <— admin form field
-      stationId: Match.Optional(Match.OneOf(String, null)), // allow null
+      host: Match.Optional(String),
+      stationId: Match.Optional(Match.OneOf(String, null)),
+      source: Match.Optional(String),
+      status: Match.Optional(String),
     });
 
     //return await checkAndCreateVisitor(data, Visitors);
@@ -94,7 +96,7 @@ Meteor.methods({
       purpose: data.purpose || 'Other',
       stationId: data.stationId ?? null,
       status: data.status || 'in_building',
-      source: data.source || 'admin',
+      source: data.source || (data.stationId ? 'kiosk' : 'public'),
       createdAt: new Date(),
     };
     return await Visitors.insertAsync(payload);

--- a/imports/api/stations/stations.methods.js
+++ b/imports/api/stations/stations.methods.js
@@ -13,71 +13,106 @@ import { assertAdminAsync } from '/imports/api/_roles.helpers.js';
 // }
 
 Meteor.methods({
-    // used by Welcome button to route to Lobby
-    async 'stations.getDefaultToken'() {
-        const lobby = await Stations.findOneAsync({ name: 'Lobby', isActive: true });
-        if (lobby) return lobby.token;
-        const firstActive = await Stations.findOneAsync({ isActive: true }, { sort: { createdAt: 1 } });
-        return firstActive?.token || null;
-    },
+  // used by Welcome button to route to Lobby
+  async 'stations.getDefaultToken'() {
+    const lobby = await Stations.findOneAsync({
+      name: 'Lobby',
+      isActive: true,
+    });
+    if (lobby) return lobby.token;
+    const firstActive = await Stations.findOneAsync(
+      { isActive: true },
+      { sort: { createdAt: 1 } },
+    );
+    return firstActive?.token || null;
+  },
 
-    // Create a kiosk (station) with configuration
-    async 'stations.create'(payload) {
-        check(payload, {
-            name: String,
-            location: String,
-            surveyId: Match.Optional(String),
-            cameraEnabled: Match.Optional(Boolean),
-            requirePhoto: Match.Optional(Boolean),
-            mobileBehavior: Match.Optional(String), // 'form_always' | 'toggle'
-            welcomeMessage: Match.Optional(String),
-            theme: Match.Optional(String),
-        });
-        await assertAdminAsync(this.userId);
+  // Create a kiosk (station) with configuration
+  async 'stations.create'(payload) {
+    check(payload, {
+      name: String,
+      location: String,
+      surveyId: Match.Optional(String),
+      cameraEnabled: Match.Optional(Boolean),
+      requirePhoto: Match.Optional(Boolean),
+      mobileBehavior: Match.Optional(String),
+      welcomeMessage: Match.Optional(String),
+      theme: Match.Optional(String),
+    });
 
-        const token = uuidv4();
-        const _id = await Stations.insertAsync({
-            ...payload,
-            token: uuidv4(),
-            isActive: true,
-            createdAt: new Date(),
-            createdBy: this.userId,
-        });
-        return { _id, token };
-    },
+    await assertAdminAsync(this.userId);
 
-    async 'stations.update'({ _id, updates }) {
-        check(_id, String);
-        check(updates, Object);
-        await assertAdminAsync(this.userId);
-        const allowed = ['name', 'location', 'surveyId', 'cameraEnabled', 'requirePhoto', 'mobileBehavior', 'welcomeMessage', 'theme', 'isActive'];
-        const $set = Object.fromEntries(Object.entries(updates).filter(([k]) => allowed.includes(k)));
-        await Stations.updateAsync(_id, { $set });
-    },
+    const name = payload.name.trim();
+    if (!name) {
+      throw new Meteor.Error('bad-request', 'Station name is required.');
+    }
 
-    async 'stations.rename'({ _id, name }) {
-        check(_id, String); check(name, String);
-        await assertAdminAsync(this.userId);
-        await Stations.updateAsync(_id, { $set: { name: name.trim() } });
-    },
+    const token = uuidv4();
 
-    async 'stations.toggle'({ _id, isActive }) {
-        check(_id, String); check(isActive, Boolean);
-        await assertAdminAsync(this.userId);
-        Stations.updateAsync(_id, { $set: { isActive } });
-    },
+    const _id = await Stations.insertAsync({
+      name,
+      location: payload.location?.trim() || '',
+      surveyId: payload.surveyId || null,
+      cameraEnabled: payload.cameraEnabled ?? true,
+      requirePhoto: payload.requirePhoto ?? false,
+      mobileBehavior: payload.mobileBehavior || 'toggle',
+      welcomeMessage: payload.welcomeMessage?.trim() || '',
+      theme: payload.theme || 'vistamate',
+      token,
+      isActive: true,
+      createdAt: new Date(),
+      createdBy: this.userId,
+    });
 
-    async 'stations.rotate'({ _id }) {
-        check(_id, String);
-        await assertAdminAsync(this.userId);
-        const token = uuidv4();
-        await Stations.updateAsync(_id, { $set: { token } });
-        return token;
-    },
+    return { _id, token };
+  },
 
-    async 'stations.remove'({ _id }) {
-        check(_id, String);
-        await assertAdminAsync(this.userId);
-        await Stations.removeAsync(_id);
-    },
+  async 'stations.update'({ _id, updates }) {
+    check(_id, String);
+    check(updates, Object);
+    await assertAdminAsync(this.userId);
+    const allowed = [
+      'name',
+      'location',
+      'surveyId',
+      'cameraEnabled',
+      'requirePhoto',
+      'mobileBehavior',
+      'welcomeMessage',
+      'theme',
+      'isActive',
+    ];
+    const $set = Object.fromEntries(
+      Object.entries(updates).filter(([k]) => allowed.includes(k)),
+    );
+    await Stations.updateAsync(_id, { $set });
+  },
+
+  async 'stations.rename'({ _id, name }) {
+    check(_id, String);
+    check(name, String);
+    await assertAdminAsync(this.userId);
+    await Stations.updateAsync(_id, { $set: { name: name.trim() } });
+  },
+
+  async 'stations.toggle'({ _id, isActive }) {
+    check(_id, String);
+    check(isActive, Boolean);
+    await assertAdminAsync(this.userId);
+    await Stations.updateAsync(_id, { $set: { isActive } });
+  },
+
+  async 'stations.rotate'({ _id }) {
+    check(_id, String);
+    await assertAdminAsync(this.userId);
+    const token = uuidv4();
+    await Stations.updateAsync(_id, { $set: { token } });
+    return token;
+  },
+
+  async 'stations.remove'({ _id }) {
+    check(_id, String);
+    await assertAdminAsync(this.userId);
+    await Stations.removeAsync(_id);
+  },
 });

--- a/imports/api/surveys/surveys.methods.js
+++ b/imports/api/surveys/surveys.methods.js
@@ -5,24 +5,54 @@ import { Surveys } from './surveys.collection';
 import { assertAdminAsync } from '../_roles.helpers';
 
 Meteor.methods({
-    async 'surveys.create'({ name, json }) {
-        check(name, String);
-        check(json, Match.OneOf(String, Object));
-        await assertAdminAsync(this.userId);
+  async 'surveys.create'({ name, json }) {
+    check(name, String);
+    check(json, Match.OneOf(String, Object));
+    await assertAdminAsync(this.userId);
 
-        let parsed = json;
-        if (typeof json === 'string') {
-            try { parsed = JSON.parse(json); }
-            catch { throw new Meteor.Error('bad-json', 'Survey JSON is invalid.'); }
-        }
+    let parsed = json;
+    if (typeof json === 'string') {
+      try {
+        parsed = JSON.parse(json);
+      } catch {
+        throw new Meteor.Error('bad-json', 'Survey JSON is invalid.');
+      }
+    }
 
-        const _id = await Surveys.insertAsync({
-            name: name.trim(),
-            json: parsed,
-            accountId: this.userId,  // connects survey to the admin account
-            createdAt: new Date(),
-            createdBy: this.userId,
-        });
-        return _id;
-    },
+    const _id = await Surveys.insertAsync({
+      name: name.trim(),
+      json: parsed,
+      accountId: this.userId, // connects survey to the admin account
+      createdAt: new Date(),
+      createdBy: this.userId,
+    });
+    return _id;
+  },
+  async 'surveys.getPublicForStation'(stationToken) {
+    check(stationToken, String);
+
+    const station = await Stations.findOneAsync({
+      token: stationToken,
+      isActive: true,
+    });
+
+    if (!station?.surveyId) {
+      return null;
+    }
+
+    const survey = await Surveys.findOneAsync(
+      { _id: station.surveyId },
+      { fields: { name: 1, json: 1 } },
+    );
+
+    if (!survey) {
+      return null;
+    }
+
+    return {
+      _id: survey._id,
+      name: survey.name,
+      json: survey.json,
+    };
+  },
 });

--- a/imports/api/surveys/surveys.methods.js
+++ b/imports/api/surveys/surveys.methods.js
@@ -3,6 +3,7 @@ import { check, Match } from 'meteor/check';
 
 import { Surveys } from './surveys.collection';
 import { assertAdminAsync } from '../_roles.helpers';
+import { Stations } from '/imports/api/stations/stations.collection';
 
 Meteor.methods({
   async 'surveys.create'({ name, json }) {

--- a/imports/ui/admin/stations/StationBuilder.jsx
+++ b/imports/ui/admin/stations/StationBuilder.jsx
@@ -35,12 +35,33 @@ export default function StationBuilder() {
   const onChange = (k, v) => setForm((f) => ({ ...f, [k]: v }));
   const create = (e) => {
     e.preventDefault();
-    Meteor.call('stations.create', form, (err, _id) => {
-      if (err) return alert(err.reason || err.message);
-      const s = Stations.findOne(_id);
-      navigator.clipboard.writeText(`${Meteor.absoluteUrl()}s/${s.token}`);
-      alert('Kiosk created. URL copied to clipboard.');
-      setForm({ ...form, name: '', location: '' });
+
+    if (!form.name.trim()) {
+      alert('Kiosk name is required.');
+      return;
+    }
+
+    Meteor.call('stations.create', form, async (err, result) => {
+      if (err) {
+        alert(err.reason || err.message);
+        return;
+      }
+
+      const kioskUrl = `${Meteor.absoluteUrl()}s/${result.token}`;
+
+      try {
+        await navigator.clipboard.writeText(kioskUrl);
+        alert('Kiosk created. URL copied to clipboard.');
+      } catch {
+        alert(`Kiosk created. URL: ${kioskUrl}`);
+      }
+
+      setForm((current) => ({
+        ...current,
+        name: '',
+        location: '',
+        welcomeMessage: '',
+      }));
     });
   };
 
@@ -158,7 +179,9 @@ export default function StationBuilder() {
                     type="checkbox"
                     className="toggle toggle-primary"
                     checked={form.cameraEnabled}
-                    onChange={(e) => onChange('cameraEnabled', e.target.checked)}
+                    onChange={(e) =>
+                      onChange('cameraEnabled', e.target.checked)
+                    }
                   />
                 </label>
 

--- a/imports/ui/pages/App.jsx
+++ b/imports/ui/pages/App.jsx
@@ -78,7 +78,11 @@ export const App = ({ stationId, kioskConfig = {}, assignedSurveyJson }) => {
           //Meteor.call('visitors.checkIn', finalData, (err, res) => {
           Meteor.call(
             'visitors.checkIn',
-            { ...finalData, stationId },
+            {
+              ...finalData,
+              stationId: stationId ?? null,
+              source: stationId ? 'kiosk' : 'public',
+            },
             (err, res) => {
               if (err) {
                 // alert('Error saving visitor: ' + err.message);

--- a/imports/ui/pages/App.jsx
+++ b/imports/ui/pages/App.jsx
@@ -12,7 +12,7 @@ import CameraCapture from '../components/CameraCapture';
 import PublicLayout from '../components/PublicLayout';
 import 'survey-core/survey-core.css';
 
-function applyOCRDefaults(parsed = {}) {
+function getOCRDefaults(parsed = {}) {
   return {
     name: parsed?.name ?? '',
     email: parsed?.email ?? '',

--- a/imports/ui/pages/App.jsx
+++ b/imports/ui/pages/App.jsx
@@ -12,7 +12,7 @@ import CameraCapture from '../components/CameraCapture';
 import PublicLayout from '../components/PublicLayout';
 import 'survey-core/survey-core.css';
 
-function applyOCRDefaults(parsed) {
+function applyOCRDefaults(parsed = {}) {
   return {
     name: parsed?.name ?? '',
     email: parsed?.email ?? '',
@@ -21,6 +21,11 @@ function applyOCRDefaults(parsed) {
     dob: parsed?.dob ?? '',
     address: parsed?.address ?? '',
   };
+}
+function removeEmptyValues(data = {}) {
+  return Object.fromEntries(
+    Object.entries(data).filter(([, value]) => value !== null && value !== ''),
+  );
 }
 
 //export const App = () => {
@@ -53,11 +58,15 @@ export const App = ({ stationId, kioskConfig = {}, assignedSurveyJson }) => {
 
       try {
         const ocrJson = JSON.parse(result.text);
-        // const surveyJson = generateSurveyJsonFromOCR(ocrJson);
-        const surveyJson = assignedSurveyJson
-          ? applyOCRDefaults(assignedSurveyJson, ocrJson) // use assigned survey if available
-          : generateSurveyJsonFromOCR(ocrJson);
+        const ocrDefaults = getOCRDefaults(ocrJson);
+        const surveyJson =
+          assignedSurveyJson || generateSurveyJsonFromOCR(ocrJson);
+
         const model = new Model(surveyJson);
+        model.data = {
+          ...(model.data || {}),
+          ...removeEmptyValues(ocrDefaults),
+        };
         model.applyTheme(FlatDarkPanelless);
         model.showCompletedPage = false;
         model.onComplete.add((sender) => {

--- a/imports/ui/stations/Stationkiosk.jsx
+++ b/imports/ui/stations/Stationkiosk.jsx
@@ -1,51 +1,120 @@
 /* eslint-disable-next-line unused-imports/no-unused-imports */
-import React from 'react';
-import { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { Meteor } from 'meteor/meteor';
 import { useParams } from 'react-router-dom';
-import { useSubscribe, useFind } from 'meteor/react-meteor-data';
+import { useSubscribe, useTracker } from 'meteor/react-meteor-data';
 
 import { Stations } from '/imports/api/stations/stations.collection';
-import { Surveys } from '/imports/api/surveys/surveys.collection';
+import App from '/imports/ui/pages/App';
+
+function normalizeSurveyJson(value) {
+  if (!value) return null;
+  if (typeof value === 'object') return value;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return null;
+  }
+}
 
 export default function StationKiosk() {
-    const { token } = useParams();
-    const subStation = useSubscribe('stations.byToken', token)();
-    const station = useFind(() => Stations.findOne({ token }), [token]);
-    const surveyId = station?.surveyId
-    const subSurvey = useSubscribe('surveys.byId', surveyId);
-    const survey = useFind(
-        () => (surveyId ? Surveys.findOne(surveyId) : undefined),
-        [surveyId]
-    );
-    useEffect(() => {
-        if (station?.theme) document.documentElement.setAttribute('data-theme', station.theme);
-        if (station?.name) document.title = `Vistamate • ${station.name}`;
-    }, [station?.theme, station?.name]);
+  const { token } = useParams();
 
-    const stationReady = subStation();
-    const surveyReady = !surveyId || subSurvey();
+  const stationSubscription = useSubscribe('stations.byToken', token);
+  const stationLoading = stationSubscription();
 
-    if (!stationReady || !station) {
-        return <div className="p-8">Loading station…</div>;
+  const station = useTracker(() => {
+    if (!token) return null;
+    return Stations.findOne({ token });
+  }, [token]);
+
+  const [assignedSurveyJson, setAssignedSurveyJson] = useState(null);
+  const [surveyLoading, setSurveyLoading] = useState(false);
+  const [surveyError, setSurveyError] = useState(null);
+
+  useEffect(() => {
+    if (station?.theme) {
+      document.documentElement.setAttribute('data-theme', station.theme);
     }
 
-    if (surveyId && (!surveyReady || !survey)) {
-        return <div className="p-8">Loading survey…</div>;
+    if (station?.name) {
+      document.title = `Vistamate • ${station.name}`;
     }
-    // Survey JSON can be stored as object or string; normalize to object
-    let assignedSurveyJson = null;
-    if (survey?.json) {
-        assignedSurveyJson = typeof survey.json === 'string' ? safeParseJSON(survey.json) : survey.json;
+  }, [station?.theme, station?.name]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    setAssignedSurveyJson(null);
+    setSurveyError(null);
+
+    if (!token || !station?.surveyId) {
+      setSurveyLoading(false);
+      return () => {
+        cancelled = true;
+      };
     }
 
+    setSurveyLoading(true);
+
+    Meteor.call('surveys.getPublicForStation', token, (err, result) => {
+      if (cancelled) return;
+
+      setSurveyLoading(false);
+
+      if (err) {
+        setSurveyError(err.reason || err.message || 'Unable to load survey.');
+        return;
+      }
+
+      setAssignedSurveyJson(normalizeSurveyJson(result?.json));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, station?.surveyId]);
+
+  if (stationLoading) {
     return (
-        <App
-            stationId={station._id}
-            kioskConfig={station}
-            assignedSurveyJson={assignedSurveyJson}
-        />
+      <div className="min-h-screen bg-base-200 p-8 text-base-content">
+        Loading station…
+      </div>
     );
-}
-function safeParseJSON(s) {
-    try { return JSON.parse(s); } catch { return null; }
+  }
+
+  if (!station) {
+    return (
+      <div className="min-h-screen bg-base-200 p-8 text-base-content">
+        This kiosk link is invalid or inactive.
+      </div>
+    );
+  }
+
+  if (surveyLoading) {
+    return (
+      <div className="min-h-screen bg-base-200 p-8 text-base-content">
+        Loading kiosk survey…
+      </div>
+    );
+  }
+
+  if (surveyError) {
+    return (
+      <div className="min-h-screen bg-base-200 p-8 text-base-content">
+        <div className="alert alert-error max-w-xl">
+          <span>{surveyError}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <App
+      stationId={station._id}
+      kioskConfig={station}
+      assignedSurveyJson={assignedSurveyJson}
+    />
+  );
 }


### PR DESCRIPTION
This PR fixes the station/kiosk check-in flow so each station URL can correctly load its assigned kiosk page and save visitor check-ins under the correct station.

- Fixed station token creation in `stations.methods.js` so the same UUID token is saved in MongoDB and returned to the frontend.
- Updated `Stationkiosk.jsx` to load the correct station using the `/s/:token` route.
- Added public-safe assigned survey loading through `surveys.getPublicForStation` in `surveys.methods.js`.
- Updated `App.jsx` so OCR data is applied correctly to either the assigned survey or generated default survey.
- Updated `visitors.checkIn` so kiosk submissions are saved with `stationId` and `source: "kiosk"`.